### PR TITLE
parameterize launchdarkly environment using env variables

### DIFF
--- a/functions/helpers.js
+++ b/functions/helpers.js
@@ -15,7 +15,7 @@ module.exports = {
 				"comment": `This is an Automated MABs allocation. Treatment: ${treatmentName} assigned.`,
 				"patch": [{ 
 					"op": "replace",
-					"path": "/environments/production/fallthrough/rollout/experimentAllocation/defaultVariation",
+					"path": `/environments/${process.env.ENV}/fallthrough/rollout/experimentAllocation/defaultVariation`,
 					"value": index
 				}]
 			})
@@ -38,7 +38,7 @@ module.exports = {
 				"comment": `This is an Automated MABs allocation. Treatment: ${treatmentName} assigned.`,
 				"patch": [{ 
 						"op": "replace",
-						"path": "/environments/production/rules/"+findExperiment+"/rollout/experimentAllocation/defaultVariation",
+						"path": `/environments/${process.env.ENV}/rules/`+findExperiment+"/rollout/experimentAllocation/defaultVariation",
 						"value": index
 					}]
 			})

--- a/functions/mabs.js
+++ b/functions/mabs.js
@@ -35,7 +35,7 @@ module.exports = {
 				flagData = json[1]
 				metadata = json[0].metadata
 				totals = json[0].totals
-				let on = flagData.environments.production.on
+				let on = flagData.environments[`${process.env.ENV}`].on
 				let isExperimentActive = flagData.experiments.items[0].environments
 
 			//Guard Clauses
@@ -48,7 +48,8 @@ module.exports = {
 
 			//Your maximum conversion rate
 			let maxConversion = Math.max.apply(Math, completeMetadata.map((variant) => { 
-				return variant.cumulativeConversionRate.toFixed(3) * 100;
+				if (variant.cumulativeConversionRate == null) return 0
+				else return variant.cumulativeConversionRate.toFixed(3) * 100;
 			}))
 
 			//Output the best performer for 'now'
@@ -58,7 +59,7 @@ module.exports = {
 			})
 			.then(bandit => {
 			//Where is the Experiment running? Rules OR Fallthrough
-				let rules = flagData.environments.production.rules
+				let rules = flagData.environments[`${process.env.ENV}`].rules
 				let findExperiment = rulesHelper.rules(rules)
 				//console.log(findExperiment)
 


### PR DESCRIPTION
There were a couple of places in the code where the LaunchDarkly environment was hard-coded. This update uses the already existing env parameters to choose the LaunchDarkly environment.

There is also one small check for null in case a variant does not have any value. It defaults to 0 in that case.