### PR TITLE
Add ld.close method to node app so that it will exit upon completion

### DIFF
--- a/app.js
+++ b/app.js
@@ -50,3 +50,5 @@ ldClient.variation(process.env.FLAG, context, ", something is wrong?!?",
 	})
 
 mabs.epsilonBandits();
+
+ldClient.close();


### PR DESCRIPTION
In order to have the Node server exit when it's completed, we need to call close on the ldClient.